### PR TITLE
paths: Only set default pip-app dir if unset

### DIFF
--- a/pip-app.sh
+++ b/pip-app.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-export PIPAPP_DIR="$HOME/.pip-apps"
+export PIPAPP_DIR="${PIPAPP_DIR:=${HOME}/.pip-apps}"
 export PATH="$PIPAPP_DIR/bin:$PATH"
 
 pip-app () {


### PR DESCRIPTION
Allow the user to have a different pip-app directory and only set the
default value if the environment variable `PIPAPP_DIR` is unset.
