### PR TITLE
shell: `pip-app` works equally well with Bash

### DIFF
--- a/pip-app.sh
+++ b/pip-app.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env zsh
-
 export PIPAPP_DIR="$HOME/.pip-apps"
 export PATH="$PIPAPP_DIR/bin:$PATH"
 


### PR DESCRIPTION
The shebang is not necessary when sourcing a file, only when executing
it.  `pip-app` works equally well with Bash and by skipping the shebang
it can be used on a machine where `zsh` is unavailable.
